### PR TITLE
feat: new clear context command,

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,14 +1,19 @@
 {
-    // channel categories of Discord where the bot will work
+    "description": "channel categories of Discord where the bot will work",
     "channelCategories"       : [
         "1111111111111111111"
     ],
-    // channels to ignore in the category
+
+    "description": "channels to ignore in the category",
     "channelToIgnore"       : [
         "1111111111111111111"
     ],
-    // roles that can access to the config (not implemented yet)
+
+    "description": "roles that can access to the config (not implemented yet)",
     "configAccess"   : [
         "295590905132482561"
-    ]
+    ],
+    
+    "description": "Number of messages that the bot will ignore (starting to the beginning of the chat history)",
+    "messagesCountToIgnore": 0
 }

--- a/config.json
+++ b/config.json
@@ -13,6 +13,9 @@
     "configAccess"   : [
         "295590905132482561"
     ],
+
+    "description": "Message that will be displayed when the context is cleared",
+    "clearContextMessage": "Context cleared!",
     
     "description": "Number of messages that the bot will ignore (starting to the beginning of the chat history)",
     "messagesCountToIgnore": 0

--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -42,7 +42,7 @@ async function getGroqChatCompletion(author: string, input: string, context: Arr
 
     // If context is provided, append it to the message list
     if (context && context.length > 0) {
-        messages.push(...context);
+        messages.unshift(...context);
     }
 
     // Use Groq client to create a chat completion request

--- a/src/commands/clear.ts
+++ b/src/commands/clear.ts
@@ -1,0 +1,18 @@
+import { ApplicationCommandOptionType, ChatInputCommandInteraction } from "discord.js";
+import { clearContextMessage } from "../../config.json";
+
+
+export default {
+    name: "clear",
+    description: "cleaning functions",
+    options: [
+        {
+            name: "context",
+            description: "Clear the context given to the AI",
+            type: ApplicationCommandOptionType.Subcommand,
+            execute: async (interaction: ChatInputCommandInteraction) => {
+                interaction.reply(clearContextMessage);
+            }
+        },
+    ]
+};

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -84,7 +84,11 @@ async function getContext(messages: GuildMessageManager | DMMessageManager, clie
         );
 
         // Remove the current message from the context
-        contextMessages.shift();
+        contextMessages.pop();
+        // Ignore first messages
+        for (let i = 0; i < messagesCountToIgnore; i++) {
+            contextMessages.shift();
+        }
 
         return contextMessages;
     });

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -2,6 +2,8 @@ import AI                                                                       
 import { Client, DMMessageManager, GuildMessageManager, Message, MessageType }  from "discord.js";
 import { splitTextIntoChunks } from "../utils/strings";
 import constants from "../utils/constants";
+import { clearContextMessage, messagesCountToIgnore } from "../../config.json";
+
 
 /**
  * This event listener handles incoming message creation events.
@@ -82,6 +84,11 @@ async function getContext(messages: GuildMessageManager | DMMessageManager, clie
                 return { role, content };
             }
         );
+
+        const lastContextReset = contextMessages.filter(message => (message.role === "assistant" && message.content === clearContextMessage)).at(-1);
+        if (lastContextReset) {
+            contextMessages.splice(0, contextMessages.indexOf(lastContextReset)+1);
+        }
 
         // Remove the current message from the context
         contextMessages.pop();


### PR DESCRIPTION
Add new clear context command to allow the user to reset the discussion without deleting all the messages 6e6975967eb6455d96eb5b621a574523787a62aa
Now properly organize context chronologically 6e6975967eb6455d96eb5b621a574523787a62aa

I removed the comments in the config.json file because comments are not supported in JSON and trigger errors when building, I replaced them with multiple "description" keys, this only triggers a non-blocking warning for a duplicate key