### PR TITLE
Impr/split text into chunks

### DIFF
--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -74,7 +74,7 @@ async function getGroqChatCompletion(author: string, input: string, context: Arr
     // Use Groq client to create a chat completion request
     return groq.chat.completions.create({
         messages    : messages,
-        model       : model,    // Specifying the Groq model for chat completions
+        model       : model,                // Specifying the Groq model for chat completions
         stream      : false,                // Disabling message streaming
         temperature : 1,                    // Setting the randomness/creativity of the response (1 = default)
     });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -7,30 +7,37 @@
  */
 export function splitTextIntoChunks(text: string, maxLength: number = 2000): string[] {
     const chunks: string[] = [];
+    const BREAKABLE_CHARACTERS = [["\n", "\r\n"], [".", "!", "?"], [","], [" "], ["/", "-", "_", ")", "]", "\""]]; // the order counts as priority order
+    const MINIMAL_FILLING = 2/3; // if the message is too long, this ensures that each chunk will not be smaller than this proportion of maxLength
     let currentIndex = 0;
 
     while (currentIndex < text.length) {
-        let nextIndex = currentIndex + maxLength;
+        let nextIndex = currentIndex + maxLength - 1;
 
         if (nextIndex >= text.length) {
             chunks.push(text.substring(currentIndex));
             break;
         }
 
-        // Ensure the chunk ends at the end of a word
-        if (text[nextIndex] !== ' ') {
-            while (nextIndex > currentIndex && text[nextIndex] !== ' ') {
+        // Ensure the chunk ends with a breakable character
+        for (let i = 0; i < BREAKABLE_CHARACTERS.length; i++) {
+            while (nextIndex > currentIndex + MINIMAL_FILLING*maxLength && !BREAKABLE_CHARACTERS[i]!.includes(text[nextIndex]!)) {
                 nextIndex--;
+            }
+            if (nextIndex === currentIndex) {
+                nextIndex = currentIndex + maxLength - 1;
+            } else {
+                break;
             }
         }
 
         // If no space found, cut at maxLength (word will be cut)
         if (nextIndex === currentIndex) {
-            nextIndex = currentIndex + maxLength;
+            nextIndex = currentIndex + maxLength - 1;
         }
 
-        chunks.push(text.substring(currentIndex, nextIndex).trim());
-        currentIndex = nextIndex + 1; // move past the space
+        chunks.push(text.substring(currentIndex, nextIndex+1).trim());
+        currentIndex = nextIndex+1; // move past the space
     }
 
     return chunks;


### PR DESCRIPTION
Improve the splitTextIntoChunks function: instead of splitting at the nearest space, it will now split at the nearest LF, then space, then other "breakable" character. It also tries to maximise the length of each message by falling back on a more common "breakable" character if the length of the trimmed message drop below 2/3 of the maxLength for example.
2e0453cfca68f74127b24e87b370a4c7d5657f88